### PR TITLE
Use directly toString instead of toRegExp as faster alternative

### DIFF
--- a/lib/rules/optimize-regex.js
+++ b/lib/rules/optimize-regex.js
@@ -40,9 +40,9 @@ module.exports = {
         return;
       }
 
-      const optimizedRegex = optimize(value).toRegExp();
+      const optimizedRegex = optimize(value).toString();
 
-      if (value === optimizedRegex.toString()) {
+      if (value === optimizedRegex) {
         return;
       }
 
@@ -54,7 +54,7 @@ module.exports = {
           optimized: optimizedRegex,
         },
         fix(fixer) {
-          return fixer.replaceText(node, optimizedRegex.toString());
+          return fixer.replaceText(node, optimizedRegex);
         },
       });
     }


### PR DESCRIPTION
`TransformResult` in `regexp-tree` has direct `toString` method (instead of creating an actual regexp with `toRegExp` method, and then calling `toString` again).