### PR TITLE
Preserve original regexp flags order

### DIFF
--- a/lib/rules/optimize-regex.js
+++ b/lib/rules/optimize-regex.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const { optimize } = require('regexp-tree');
+const { parse, generate, optimize } = require('regexp-tree');
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -40,9 +40,26 @@ module.exports = {
         return;
       }
 
+      let parsedSource;
+      try {
+        parsedSource = parse(value);
+      } catch (e) {
+        context.report({
+          node,
+          message: '{{original}} can\'t be parsed: {{message}}',
+          data: {
+            original: value,
+            message: e.message
+          }
+        });
+
+        return;
+      }
+
+      const originalRegex = generate(parsedSource).toString();
       const optimizedRegex = optimize(value).toString();
 
-      if (value === optimizedRegex) {
+      if (originalRegex === optimizedRegex) {
         return;
       }
 

--- a/tests/lib/rules/optimize-regex.js
+++ b/tests/lib/rules/optimize-regex.js
@@ -14,7 +14,10 @@ var rule = require('../../../lib/rules/optimize-regex'),
 
 var ruleTester = new RuleTester();
 ruleTester.run('optimize-regex', rule, {
-  valid: ['var foo = /foo/i'],
+  valid: [
+    'var foo = /foo/i',
+    'var foo = /foo/mig'
+  ],
 
   invalid: [
     {


### PR DESCRIPTION
Regexp flags order isn't important, so it is better to use real regexp instead of its string representation.

    /foo/mig.toString() = /foo/gim