### PR TITLE
Update regexp-tree to 0.0.83

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-optimize-regex",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -217,7 +217,7 @@
       "resolved": "https://registry.npmjs.org/cli-table2/-/cli-table2-0.2.0.tgz",
       "integrity": "sha1-LR738hig54biFFQFYtS9F3/jLZc=",
       "requires": {
-        "colors": "1.1.2",
+        "colors": "1.2.1",
         "lodash": "3.10.1",
         "string-width": "1.0.2"
       },
@@ -236,13 +236,42 @@
       "dev": true
     },
     "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+      "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
         "wrap-ansi": "2.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "co": {
@@ -272,9 +301,9 @@
       "dev": true
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg=="
     },
     "commander": {
       "version": "2.11.0",
@@ -1045,17 +1074,25 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -1145,13 +1182,13 @@
       }
     },
     "regexp-tree": {
-      "version": "0.0.72",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.0.72.tgz",
-      "integrity": "sha512-gbcynDzyATdQpWVM6cBUau/Vkvrc7NLZ8GZoQ6/k0SAHqPkhkIqvCFcQne/Pmsw9QXRN+RQXoqVSASxZjboWnA==",
+      "version": "0.0.83",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.0.83.tgz",
+      "integrity": "sha512-FFve5CXiUrwFdkntmmQJ5dzr/3gQok5Hk1UxjarBzp+d2i0184zyMXlbgbEQPXEkTdpuY0H/Mg/3vKz/tYo/UA==",
       "requires": {
         "cli-table2": "0.2.0",
-        "colors": "1.1.2",
-        "yargs": "10.0.3"
+        "colors": "1.2.1",
+        "yargs": "10.1.2"
       }
     },
     "require-directory": {
@@ -1289,16 +1326,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      },
-      "dependencies": {
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
       }
     },
     "string_decoder": {
@@ -1484,11 +1511,11 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-      "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
       "requires": {
-        "cliui": "3.2.0",
+        "cliui": "4.0.0",
         "decamelize": "1.2.0",
         "find-up": "2.1.0",
         "get-caller-file": "1.0.2",
@@ -1499,7 +1526,7 @@
         "string-width": "2.1.1",
         "which-module": "2.0.0",
         "y18n": "3.2.1",
-        "yargs-parser": "8.0.0"
+        "yargs-parser": "8.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1532,9 +1559,9 @@
       }
     },
     "yargs-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-      "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+      "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "requires": {
         "camelcase": "4.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "mocha tests --recursive"
   },
   "dependencies": {
-    "regexp-tree": "0.0.72"
+    "regexp-tree": "0.0.83"
   },
   "devDependencies": {
     "eslint": "^4.12.1",

--- a/tests/lib/rules/optimize-regex.js
+++ b/tests/lib/rules/optimize-regex.js
@@ -19,6 +19,7 @@ ruleTester.run('optimize-regex', rule, {
     'var foo = /bar/mig',
     'var foo = /\\/\\./',
     'var foo = /[/\\\\]$/',
+    'var re = /foo/',
   ],
 
   invalid: [
@@ -29,14 +30,6 @@ ruleTester.run('optimize-regex', rule, {
         {
           message:
             '/[a-zA-Z_0-9][A-Z_\\da-z]*\\e{1,}/ can be optimized to /\\w+e+/',
-          type: 'Literal',
-        },
-      ],
-      code: 'var re = /foo/',
-      output: 'var re = /fo{2}/',
-      errors: [
-        {
-          message: '/foo/ can be optimized to /fo{2}/',
           type: 'Literal',
         },
       ],


### PR DESCRIPTION
Fixes an unexpected behavior where regexp-tree produced a longer regexp than the original one.

See https://github.com/DmitrySoshnikov/regexp-tree/pull/151

Since this is a potential breaking change, you should do a major version bump when publishing the module :)