### PR TITLE
- Add `meta.type`

### DIFF
--- a/lib/rules/optimize-regex.js
+++ b/lib/rules/optimize-regex.js
@@ -17,6 +17,7 @@ const transforms = [...optimizerTransforms.keys()]
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Optimize regex literals',
       category: 'Possible Improvements',


### PR DESCRIPTION
I set `meta.type` to "suggestion", though if you prefer to interpret optimizing as a problem, I could switch to "problem".

Besides a `meta.type` allowing use with `eslint --fix-type`, the type is reported to formatters (my [eslint-formatter-badger](https://github.com/brettz9/eslint-formatter-badger), or example, can be used to count the number of passing or failing linted rules by type).