### PR TITLE
fix readme.md description of how to user extends of eslint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you want the latter particular settings, you can avoid setting `plugins` and
 
 ```json
 {
-  "extends": ["optimize-regex/recommended"]
+  "extends": ["plugin:optimize-regex/recommended"]
 }
 ```
 
@@ -69,7 +69,7 @@ Or without the blacklist:
 
 ```json
 {
-  "extends": ["optimize-regex/all"]
+  "extends": ["plugin:optimize-regex/all"]
 }
 ```
 


### PR DESCRIPTION
As described [here ](https://eslint.org/docs/user-guide/configuring/configuration-files#using-a-configuration-from-a-plugin) we should use "plugin:" prefix before the shortened package name "optimize-regex".